### PR TITLE
Update query type hint in QueryParamFilterStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.11.0] - 2024-03-15
+### Fixed
+- Fix Cannot assign Symfony\Component\HttpFoundation\ParameterBag to property Symfony\Component\HttpFoundation\Request::$query of type Symfony\Component\HttpFoundation\InputBag 
+  - Starting with Symfony 7 (Drupal 11), the query propertie has been updated with more specific type-hint. It is now explicitly typed as Symfony\Component\HttpFoundation\InputBag. 
 
 ## [1.10.1] - 2024-03-15
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=8.1",
-        "drupal/core": "^10.1 || ^11.0"
+        "drupal/core": "^11.0"
     },
     "require-dev": {
         "ergebnis/composer-normalize": "^2.0",

--- a/src/FilterStorage/QueryParamFilterStorage.php
+++ b/src/FilterStorage/QueryParamFilterStorage.php
@@ -5,7 +5,7 @@ namespace Drupal\wmentity_overview\FilterStorage;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\wmentity_overview\Annotation\FilterStorage;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -63,15 +63,15 @@ class QueryParamFilterStorage extends FilterStorageBase implements ContainerFact
 
     public function reset(): void
     {
-        $this->getRequest()->query = new ParameterBag;
+        $this->getRequest()->query = new InputBag;
     }
 
-    protected function getParams(): ParameterBag
+    protected function getParams(): InputBag
     {
         $request = $this->getRequest();
 
         if (!$request) {
-            return new ParameterBag;
+            return new InputBag;
         }
 
         return $request->query;

--- a/wmentity_overview.info.yml
+++ b/wmentity_overview.info.yml
@@ -1,5 +1,5 @@
 name: Entity Overview
 type: module
 description: Improved EntityListBuilders with support for paging, table sorting, table dragging, filtering, bulk actions, database queries and more.
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^11
 package: Wieni


### PR DESCRIPTION
In Symfony versions prior to 7, the properties that hold request data (query, request, attributes, etc.) on the Request object were more flexible. They were typed to accept the more general Symfony\Component\HttpFoundation\ParameterBag.

Starting with Symfony 7, these properties have been updated with more specific type-hints. For instance, the $query property is now explicitly typed as Symfony\Component\HttpFoundation\InputBag.

Here’s a breakdown of the change:

Before Symfony 7:
public Symfony\Component\HttpFoundation\ParameterBag $query;

In Symfony 7:
public Symfony\Component\HttpFoundation\InputBag $query;

The same change applies to other properties like $request (for POST data) and $cookies, which are also now type-hinted as InputBag.
